### PR TITLE
Removed `preinstall` script and updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#12](https://github.com/equinor/flow-diagram-explorer/pull/12) - Removed `preinstall` script (when installing with npm >= 7.*, use `--legacy-peer-deps`).
+
+## [1.0.0-alpha1] - 2021-08-24
+
+### Changed
+
 -   [#11](https://github.com/equinor/flow-diagram-explorer/pull/11) - Renamed `from` to `fromNode` and `to` to `toNode` in `FlowDiagramEdge`. Also replaced `diagram-drawer.tsx` with `diagram-drawer-advanced.tsx` and removed the latter.
 
 ## [1.0.0-alpha] - 2021-08-18

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "packages": {
         "": {
             "name": "@equinor/flow-diagram-explorer",
-            "hasInstallScript": true,
             "license": "MPL-2.0",
             "dependencies": {
                 "@date-io/dayjs": "^1.3.13",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "scripts": {
         "predeploy": "npm run build",
         "deploy": "gh-pages -d build",
-        "preinstall": "npx npm-force-resolutions",
         "start": "webpack serve --mode development --devtool inline-source-map --entry ./src/demo/index.tsx --open",
         "build": "webpack --mode production --entry ./src/demo/index.tsx",
         "prepack": "tsc",


### PR DESCRIPTION
Removed `preinstall` script (when installing with npm >= 7.*, use `--legacy-peer-deps`).