### PR TITLE
Adjusted diagram node template style.

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "equinor_flow_diagram_explorer.cjs.js": {
-    "bundled": 1847355,
-    "minified": 956568,
-    "gzipped": 229636
+    "bundled": 1847360,
+    "minified": 956573,
+    "gzipped": 229639
   },
   "equinor_flow_diagram_explorer.umd.js": {
-    "bundled": 1953995,
-    "minified": 781768,
-    "gzipped": 207735
+    "bundled": 1954000,
+    "minified": 781773,
+    "gzipped": 207737
   },
   "equinor_flow_diagram_explorer.esm.js": {
-    "bundled": 1833587,
-    "minified": 944070,
-    "gzipped": 229050,
+    "bundled": 1833592,
+    "minified": 944075,
+    "gzipped": 229052,
     "treeshaked": {
       "rollup": {
-        "code": 664460,
+        "code": 664465,
         "import_statements": 448
       },
       "webpack": {
-        "code": 720077
+        "code": 720082
       }
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   [#40](https://github.com/equinor/flow-diagram-explorer/pull/40) - Changed `whitespace` CSS property of diagram node template to `pre-wrap` and aligned text in center.
+
+## [1.0.0-alpha6] - 2021-10-05
+
+### Fixed
+
 -   [#31](https://github.com/equinor/flow-diagram-explorer/pull/31) - Fixed inconsistent behaviour at timeline borders.
 -   [#32](https://github.com/equinor/flow-diagram-explorer/pull/32) - Fixed width and height issue with timeline container.
 

--- a/src/lib/render-library/Template/template.css
+++ b/src/lib/render-library/Template/template.css
@@ -9,7 +9,8 @@
     color: #233746;
     border-radius: 4px;
     font-size: 1em;
-    white-space: pre;
+    white-space: pre-wrap;
+    text-align: center;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Changed `whitespace` CSS property of diagram node template to `pre-wrap` and aligned text in center.

Closes #39.