### PR TITLE
Replace material UI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-alpha6] - 2021-10-05
 
+## Changed
+
+-   [#61](https://github.com/equinor/flow-diagram-explorer/pull/61) - Replaced all MUI components with EDS
+
 ### Fixed
 
 -   [#31](https://github.com/equinor/flow-diagram-explorer/pull/31) - Fixed inconsistent behaviour at timeline borders.

--- a/src/lib/components/FlowDiagramExplorer/flow-diagram-explorer.css
+++ b/src/lib/components/FlowDiagramExplorer/flow-diagram-explorer.css
@@ -5,21 +5,21 @@
 
 .FlowDiagramExplorer__Levels {
     position: absolute;
-    padding: 16px;
-    background-color: white;
-    box-shadow: 0px 3px 5px #888888;
-    top: 16px;
-    left: 16px;
-    height: 20px;
     display: block;
-    border-radius: 4px;
+    top: 1rem;
+    left: 1rem;
+    height: 20px;
+    padding: 1rem;
+    background-color: white;
+    box-shadow: 0 3px 5px #888888;
+    border-radius: 0.25rem;
     z-index: 10;
 }
 
 .FlowDiagramExplorer__TimelineContainer {
     position: absolute;
-    bottom: 16px;
-    right: 150px;
-    left: 250px;
+    bottom: 1rem;
     z-index: 10;
+    width: 100%;
+    display: grid;
 }

--- a/src/lib/components/MapActions/map-actions.css
+++ b/src/lib/components/MapActions/map-actions.css
@@ -1,12 +1,18 @@
 .FlowDiagramExplorer__MapActions {
     position: absolute;
-    right: 0px;
-    bottom: 0px;
+    right: 0;
+    bottom: 0;
 }
 
 button.FlowDiagramExplorer__MapActions__Fab {
-    margin: 16px;
-    background-color: white;
+    margin: 1rem;
+    background: white;
     color: #246e78;
     display: flex;
+    height: 3.5rem;
+    width: 3.5rem;
+    place-content: center;
+    box-shadow: 0 3px 5px -1px rgba(0,0,0,0.2),
+    0 6px 10px 0 rgba(0,0,0,0.14),
+    0 1px 18px 0 rgba(0,0,0,0.12);
 }

--- a/src/lib/components/MapActions/map-actions.css
+++ b/src/lib/components/MapActions/map-actions.css
@@ -2,6 +2,7 @@
     position: absolute;
     right: 0;
     bottom: 0;
+    z-index: 11;
 }
 
 button.FlowDiagramExplorer__MapActions__Fab {

--- a/src/lib/components/MapActions/map-actions.tsx
+++ b/src/lib/components/MapActions/map-actions.tsx
@@ -1,9 +1,6 @@
 import React from "react";
-import ZoomInIcon from "@material-ui/icons/ZoomIn";
-import ZoomOutIcon from "@material-ui/icons/ZoomOut";
-import FilterCenterFocusIcon from "@material-ui/icons/FilterCenterFocus";
-import { Tooltip, Button } from "@equinor/eds-core-react";
-
+import { Tooltip, Button, Icon } from "@equinor/eds-core-react";
+import { focus_center, zoom_in, zoom_out } from "@equinor/eds-icons";
 import "./map-actions.css";
 
 export enum MapActionType {
@@ -33,7 +30,7 @@ export const MapActions: React.FC<MapActionsProps> = (props) => {
                     onClick={() => handleActionTriggered(MapActionType.ZoomIn)}
                     variant="ghost_icon"
                 >
-                    <ZoomInIcon />
+                    <Icon data={zoom_in} />
                 </Button>
             </Tooltip>
             <Tooltip title="Zoom out" placement="left">
@@ -43,7 +40,7 @@ export const MapActions: React.FC<MapActionsProps> = (props) => {
                     onClick={() => handleActionTriggered(MapActionType.ZoomOut)}
                     variant="ghost_icon"
                 >
-                    <ZoomOutIcon />
+                    <Icon data={zoom_out} />
                 </Button>
             </Tooltip>
             <Tooltip title="View all" placement="left">
@@ -53,7 +50,7 @@ export const MapActions: React.FC<MapActionsProps> = (props) => {
                     onClick={() => handleActionTriggered(MapActionType.CenterView)}
                     variant="ghost_icon"
                 >
-                    <FilterCenterFocusIcon />
+                    <Icon data={focus_center} />
                 </Button>
             </Tooltip>
         </div>

--- a/src/lib/components/MapActions/map-actions.tsx
+++ b/src/lib/components/MapActions/map-actions.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import Fab from "@material-ui/core/Fab";
 import ZoomInIcon from "@material-ui/icons/ZoomIn";
 import ZoomOutIcon from "@material-ui/icons/ZoomOut";
 import FilterCenterFocusIcon from "@material-ui/icons/FilterCenterFocus";
-import { Tooltip } from "@equinor/eds-core-react";
+import { Tooltip, Button } from "@equinor/eds-core-react";
 
 import "./map-actions.css";
 
@@ -28,31 +27,34 @@ export const MapActions: React.FC<MapActionsProps> = (props) => {
     return (
         <div className="FlowDiagramExplorer__MapActions">
             <Tooltip title="Zoom in" placement="left">
-                <Fab
+                <Button
                     className="FlowDiagramExplorer__MapActions__Fab"
                     aria-label="zoom in"
                     onClick={() => handleActionTriggered(MapActionType.ZoomIn)}
+                    variant="ghost_icon"
                 >
                     <ZoomInIcon />
-                </Fab>
+                </Button>
             </Tooltip>
             <Tooltip title="Zoom out" placement="left">
-                <Fab
-                    className="FlowDiagramExplorer__MapActions__Fab"
+                <Button
                     aria-label="zoom out"
+                    className="FlowDiagramExplorer__MapActions__Fab"
                     onClick={() => handleActionTriggered(MapActionType.ZoomOut)}
+                    variant="ghost_icon"
                 >
                     <ZoomOutIcon />
-                </Fab>
+                </Button>
             </Tooltip>
             <Tooltip title="View all" placement="left">
-                <Fab
-                    className="FlowDiagramExplorer__MapActions__Fab"
+                <Button
                     aria-label="view all"
+                    className="FlowDiagramExplorer__MapActions__Fab"
                     onClick={() => handleActionTriggered(MapActionType.CenterView)}
+                    variant="ghost_icon"
                 >
                     <FilterCenterFocusIcon />
-                </Fab>
+                </Button>
             </Tooltip>
         </div>
     );

--- a/src/lib/components/Timeline/timeline.css
+++ b/src/lib/components/Timeline/timeline.css
@@ -1,46 +1,38 @@
 .FlowDiagramExplorer__Timeline {
-    position: relative;
+    display: flex;
+    flex-flow: column;
+    gap: 1rem;
+    min-width: 0;
+    padding: 0 140px 0 180px;
     user-select: none;
 }
 
-.FlowDiagramExplorer__InnerTimeline {
-    padding: 16px;
-    background-color: white;
-    box-shadow: 0px 3px 5px #888888;
-    display: block;
-    border-radius: 8px;
-}
-
 .FlowDiagramExplorer__Timeline__CurrentSelectionLabel {
-    position: absolute;
-    left: 50%;
-    margin-left: -120px;
-    width: 204px;
-    top: -75px;
-    padding-top: 12px;
-    padding-bottom: 4px;
-    padding-left: 8px;
-    padding-right: 52px;
-    background-color: white;
-    box-shadow: 0px 3px 5px #888888;
-    display: block;
-    border-radius: 8px;
-    white-space: nowrap;
-    text-align: center;
+    display: flex;
+    gap: 0.5rem;
+    margin: auto;
+    padding: 0.25rem 0.5rem;
+    align-items: center;
+    border-radius: 0.5rem;
+    background: white;
+    box-shadow: 0 3px 5px #888888;
+}
+.FlowDiagramExplorer__Timeline__CurrentSelectionLabel input {
+    min-width: 150px;
+    box-shadow: none;
+    background: none;
+    border-radius: 0.25rem;
+}
+.FlowDiagramExplorer__Timeline__CurrentSelectionLabel div {
+    flex: 1;
 }
 
-.FlowDiagramExplorer__Timeline__CurrentSelectionLabel button:first-of-type {
-    margin-right: 8px;
+.FlowDiagramExplorer__InnerTimeline {
+    padding: 1rem;
+    background: white;
+    border-radius: 0.5rem;
+    box-shadow: 0 3px 5px #888888;
 }
-
-button.FlowDiagramExplorer__Timeline__Toggle {
-    margin-top: -7px;
-}
-
-.FlowDiagramExplorer__Timeline__DatePicker {
-    width: 160px;
-}
-
 .FlowDiagramExplorer__Timeline__Frames {
     display: flex;
     position: relative;

--- a/src/lib/components/Timeline/timeline.tsx
+++ b/src/lib/components/Timeline/timeline.tsx
@@ -1,16 +1,11 @@
 import React from "react";
 import clsx from "clsx";
-import { Tooltip, Button, Icon } from "@equinor/eds-core-react";
+import { Tooltip, Button, Icon, TextField } from "@equinor/eds-core-react";
 import { visibility, visibility_off, calendar } from "@equinor/eds-icons";
 import dayjs, { Dayjs } from "dayjs";
 import isBetween from "dayjs/plugin/isBetween";
-import { MuiPickersUtilsProvider, DatePicker } from "@material-ui/pickers";
-import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
-import DayjsUtils from "@date-io/dayjs";
-
 import { useContainerDimensions } from "../../hooks/useContainerDimensions";
 import { useMousePosition } from "../../hooks/useMousePosition";
-
 import "./timeline.css";
 
 Icon.add({ visibility, visibility_off, calendar });
@@ -38,6 +33,8 @@ type TimelineProps = {
     onDateChange?: (date: Dayjs) => void;
 };
 
+type DateEvent = React.ChangeEvent<HTMLInputElement>;
+
 export const Timeline: React.FC<TimelineProps> = (props: TimelineProps): JSX.Element => {
     const [axisTicks, setAxisTicks] = React.useState<AxisTick[]>([]);
     const [frames, setFrames] = React.useState<TimeFrameItem[]>([]);
@@ -52,7 +49,6 @@ export const Timeline: React.FC<TimelineProps> = (props: TimelineProps): JSX.Ele
     const [sliderActive, setSliderActive] = React.useState(false);
     const [resolution, setResolution] = React.useState(0);
     const [hoverSliderVisible, setHoverSliderVisible] = React.useState(false);
-    const [datePickerOpen, setDatePickerOpen] = React.useState(false);
 
     React.useEffect(() => {
         if (visible) {
@@ -252,14 +248,9 @@ export const Timeline: React.FC<TimelineProps> = (props: TimelineProps): JSX.Ele
         };
     }, [setSliderActive]);
 
-    const handleDateChange = React.useCallback(
-        (date: MaterialUiPickersDate) => {
-            if (date) {
-                setCurrentDate(date.startOf("day"));
-            }
-        },
-        [setCurrentDate]
-    );
+    const handleDateChange = (e: DateEvent) => {
+        if (e?.target?.value) setCurrentDate(dayjs(e.target.value));
+    };
 
     React.useEffect(() => {
         if (props.onDateChange && currentDate) {
@@ -267,44 +258,24 @@ export const Timeline: React.FC<TimelineProps> = (props: TimelineProps): JSX.Ele
         }
     }, [currentDate]);
 
-    const toggleDatePickerDialogVisibility = () => {
-        setDatePickerOpen(!datePickerOpen);
-    };
-
     return (
         <div className="FlowDiagramExplorer__Timeline">
             {currentDate && (
                 <div className="FlowDiagramExplorer__Timeline__CurrentSelectionLabel">
-                    <Tooltip title="Open date picker dialog" placement="top">
-                        <Button
-                            className="FlowDiagramExplorer__Timeline__Toggle"
-                            variant="ghost_icon"
-                            onClick={toggleDatePickerDialogVisibility}
-                        >
-                            <Icon name="calendar" title="Current date" size={16} />
-                        </Button>
-                    </Tooltip>
-                    <MuiPickersUtilsProvider utils={DayjsUtils}>
-                        <DatePicker
-                            variant="inline"
-                            value={currentDate}
-                            onChange={handleDateChange}
-                            format="MMMM DD, YYYY"
-                            open={datePickerOpen}
-                            maxDate={
-                                sortedTimeFrames.length > 0
-                                    ? sortedTimeFrames[sortedTimeFrames.length - 1].endDate
-                                    : undefined
-                            }
-                            onOpen={() => setDatePickerOpen(true)}
-                            onClose={() => setDatePickerOpen(false)}
-                            minDate={sortedTimeFrames.length > 0 ? sortedTimeFrames[0].startDate : undefined}
-                            className="FlowDiagramExplorer__Timeline__DatePicker"
-                            InputProps={{
-                                disableUnderline: true,
-                            }}
-                        />
-                    </MuiPickersUtilsProvider>
+                    <TextField
+                        id="timeline_date"
+                        type="date"
+                        value={currentDate.format("YYYY-MM-DD")}
+                        onChange={(e: DateEvent) => handleDateChange(e)}
+                        min={
+                            sortedTimeFrames.length > 0 ? sortedTimeFrames[0].startDate.format("YYYY-MM-DD") : undefined
+                        }
+                        max={
+                            sortedTimeFrames.length > 0
+                                ? sortedTimeFrames[sortedTimeFrames.length - 1].endDate.format("YYYY-MM-DD")
+                                : undefined
+                        }
+                    />
                     <Tooltip title={visible ? "Hide timeline" : "Show timeline"} placement="top">
                         <Button
                             className="FlowDiagramExplorer__Timeline__Toggle"


### PR DESCRIPTION
# What does this PR change
1. removes components from the `@material-ui/` packages
2. replaces these with corresponding EDS components
3. rewrite logic to support EDS components
4. rewrite style to support EDS components

PR [#62](https://github.com/equinor/flow-diagram-explorer/pull/62) uninstalls the MUI packages