### PR TITLE
ci: 🔧 set node to v14 in release workflow

### DIFF
--- a/.github/workflows/flow-diagram-explorer.yml
+++ b/.github/workflows/flow-diagram-explorer.yml
@@ -19,10 +19,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: 📖 Checkout commit locally
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: set node to v14
-              - uses: actions/setup-node@v4
+              uses: actions/setup-node@v4
                 with:
                   node-version: '14.16.1'
 

--- a/.github/workflows/flow-diagram-explorer.yml
+++ b/.github/workflows/flow-diagram-explorer.yml
@@ -21,6 +21,11 @@ jobs:
             - name: 📖 Checkout commit locally
               uses: actions/checkout@v2
 
+            - name: set node to v14
+              - uses: actions/setup-node@v4
+                with:
+                  node-version: '14.16.1'
+
             - name: 📦 Install build dependencies
               run: |
                   npx npm-force-resolutions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+-   [#63](https://github.com/equinor/flow-diagram-explorer/pull/63) - Updated release workflow
 -   [#62](https://github.com/equinor/flow-diagram-explorer/pull/62) - Uninstalled MUI packages
 -   [#61](https://github.com/equinor/flow-diagram-explorer/pull/61) - Replaced all MUI components with EDS
 


### PR DESCRIPTION
`npm ci` fails on newer versions of `node`. Until we've fixed the issues introduced by later version of node, the workflow needs to use `v14.16.1`.